### PR TITLE
Fix error report for failed test.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bifrost-io",
-  "version": "0.6.19",
+  "version": "0.6.20",
   "description": "Client library for heimdall (an e2e dashboard server)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
with codeceptjs v3 there is no more 2nd err argument in Helper._failed(test) method. (That might be also [fixed in codeceptjs](https://github.com/codeceptjs/CodeceptJS/blob/3.x/lib/listener/helpers.js#L57))

Instead I subscribed to events.test.failed, where this error is provided.
 Inspired by following other helpers:
* [reportportal](https://github.com/reportportal/agent-js-codecept/blob/master/index.js)
* [testrail](https://github.com/PeterNgTr/codeceptjs-testrail/blob/master/index.js)

Other hooks seems to be without changes in methods' arguments.